### PR TITLE
Fix README code block formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To remove XFCE GUI and prep a clean, fast Kali headless build:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/quasialex/p4wnp1-zero2w/main/scripts/setup_headless_kali.sh | bash
-````
+```
 
 > ⚠️ Or run manually:
 > `sudo bash scripts/setup_headless_kali.sh`


### PR DESCRIPTION
## Summary
- fix closing backticks after the `curl` command in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1373bf9883319686c82ddad8ba94