### PR TITLE
Clarify HID key release

### DIFF
--- a/payloads/hid/test_typing.sh
+++ b/payloads/hid/test_typing.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 # Types "a" via HID (keycode 0x04)
+# Send the HID report for the key press
 /bin/echo -ne '\0\0\x04\0\0\0\0\0' > /dev/hidg0
+# Follow up with an all-zero report to release the key
+/bin/echo -ne '\0\0\0\0\0\0\0\0' > /dev/hidg0
 sleep 0.1
+


### PR DESCRIPTION
## Summary
- clarify how the HID typing test releases the key

## Testing
- `shellcheck payloads/hid/test_typing.sh`


------
https://chatgpt.com/codex/tasks/task_e_687e137a0c5883319bca0f969393a9f5