### PR TITLE
Improve payload launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Run a payload manually:
 sudo bash /opt/p4wnp1/payloads/network/rogue_dhcp_dns.sh
 ```
 
+To execute the currently selected payload (as defined in
+`config/active_payload`), simply run:
+
+```bash
+sudo /opt/p4wnp1/run.sh
+```
+
 ---
 
 ## 📡 OLED Menu (WIP)

--- a/run.sh
+++ b/run.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # === Config ===
 # Allow overriding the project location via P4WN_HOME
 P4WN_HOME="${P4WN_HOME:-/opt/p4wnp1}"
-ACTIVE_PAYLOAD="$P4WN_HOME/config/active_payload"
-PAYLOADS_DIR="$P4WN_HOME/payloads"
+ACTIVE_FILE="$P4WN_HOME/config/active_payload"
+PAYLOADS_JSON="$P4WN_HOME/config/payload.json"
 LOG="$P4WN_HOME/logs/runner.log"
 
 mkdir -p "$(dirname "$LOG")"
@@ -24,20 +24,33 @@ echo "[*] Setting up networking..."
 bash "$P4WN_HOME/config/setup_net.sh"
 sleep 1
 
-# === Read active payload ===
-if [[ ! -f "$ACTIVE_PAYLOAD" ]]; then
-  echo "[!] No active payload file found at $ACTIVE_PAYLOAD"
+# Ensure jq is available for reading payload config
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[!] jq command not found. Please install jq." >&2
   exit 1
 fi
 
-PAYLOAD_ID=$(cat "$ACTIVE_PAYLOAD")
-PAYLOAD_PATH="$PAYLOADS_DIR/$PAYLOAD_ID"
+# === Read active payload ===
+if [[ ! -f "$ACTIVE_FILE" ]]; then
+  echo "[!] No active payload file found at $ACTIVE_FILE"
+  exit 1
+fi
+
+PAYLOAD_ID=$(cat "$ACTIVE_FILE")
+PAYLOAD_PATH=$(jq -r --arg id "$PAYLOAD_ID" '.[$id].path' "$PAYLOADS_JSON")
+
+if [[ -z "$PAYLOAD_PATH" || "$PAYLOAD_PATH" == "null" ]]; then
+  echo "[!] Payload '$PAYLOAD_ID' not found in config $PAYLOADS_JSON"
+  exit 1
+fi
+
+FULL_PATH="$P4WN_HOME/$PAYLOAD_PATH"
 
 # === Run payload ===
-if [[ -x "$PAYLOAD_PATH" ]]; then
-  echo "[+] Executing payload: $PAYLOAD_ID"
-  "$PAYLOAD_PATH"
+if [[ -x "$FULL_PATH" ]]; then
+  echo "[+] Executing payload: $PAYLOAD_ID -> $FULL_PATH"
+  "$FULL_PATH"
 else
-  echo "[!] Payload not found or not executable: $PAYLOAD_PATH"
+  echo "[!] Payload not found or not executable: $FULL_PATH"
   exit 1
 fi

--- a/run_payload.sh
+++ b/run_payload.sh
@@ -1,24 +1,5 @@
 #!/bin/bash
-# Executes the payload selected in active_payload file
-
+# Wrapper for backward compatibility - launches run.sh which handles
+# gadget setup and payload execution based on the active payload file.
 P4WN_HOME="${P4WN_HOME:-/opt/p4wnp1}"
-CONFIG="$P4WN_HOME/config/payload.json"
-ACTIVE="$P4WN_HOME/config/active_payload"
-
-if [ ! -f "$ACTIVE" ]; then
-  echo "[!] No active payload set."
-  exit 1
-fi
-
-PAYLOAD_ID=$(cat "$ACTIVE")
-PAYLOAD_PATH=$(jq -r --arg id "$PAYLOAD_ID" '.[$id].path' "$CONFIG")
-
-if [ -z "$PAYLOAD_PATH" ] || [ "$PAYLOAD_PATH" == "null" ]; then
-  echo "[!] Payload '$PAYLOAD_ID' not found in config."
-  exit 1
-fi
-
-FULL_PATH="$P4WN_HOME/$PAYLOAD_PATH"
-echo "[+] Running payload: $PAYLOAD_ID -> $FULL_PATH"
-chmod +x "$FULL_PATH"
-"$FULL_PATH"
+exec "$P4WN_HOME/run.sh"


### PR DESCRIPTION
## Summary
- unify payload execution logic in `run.sh`
- wrap existing `run_payload.sh` as a compatibility shim
- mention `run.sh` usage in README

## Testing
- `bash -n run.sh`
- `bash -n run_payload.sh`
- `find . -name '*.sh' -exec bash -n {} +`
- `find . -name '*.py' -print0 | xargs -0 python3 -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_687e4b08a7288331832d6770442cc08a