### PR TITLE
Fix active payload selection logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ sudo bash /opt/p4wnp1/payloads/network/rogue_dhcp_dns.sh
 ```
 
 To execute the currently selected payload (as defined in
-`config/active_payload`), simply run:
+`config/active_payload`, which stores the payload **ID** from
+`config/payload.json`), simply run:
 
 ```bash
 sudo /opt/p4wnp1/run.sh

--- a/config/active_payload
+++ b/config/active_payload
@@ -1,1 +1,1 @@
-hid/test_typing.sh
+rogue_dhcp_dns

--- a/hooks/select_payload.sh
+++ b/hooks/select_payload.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
-# List enabled payloads from payload.json
-jq -r 'to_entries[] | select(.value.enabled == true) | "\(.key): \(.value.name)"' /opt/p4wnp1/config/payload.json
+P4WN_HOME="${P4WN_HOME:-/opt/p4wnp1}"
+CFG="$P4WN_HOME/config/payload.json"
 
-echo ""
-echo "Enter the payload path to activate (e.g., hid/test_typing.sh):"
-read NEW
+# List enabled payload IDs from payload.json
+PAYLOADS=$(jq -r 'keys[] as $k | select(.[$k].enabled == true) | $k' "$CFG")
 
-# Validate
-if [[ -x /opt/p4wnp1/payloads/$NEW ]]; then
-  echo "$NEW" > /opt/p4wnp1/config/active_payload
+echo "Available payloads:"
+printf '%s\n' "$PAYLOADS"
+echo
+read -p "Enter the payload ID to activate: " NEW
+
+# Validate that the ID exists
+if jq -e --arg id "$NEW" '.[$id]?' "$CFG" >/dev/null; then
+  echo "$NEW" > "$P4WN_HOME/config/active_payload"
   echo "Active payload updated to: $NEW"
 else
   echo "Invalid selection. No changes made."


### PR DESCRIPTION
## Summary
- clarify README about active payload ID
- fix `hooks/select_payload.sh` to use payload IDs
- update `config/active_payload` default

## Testing
- `bash -n hooks/select_payload.sh`
- `shellcheck hooks/select_payload.sh`
- `P4WN_HOME=$PWD bash hooks/select_payload.sh <<'EOF'
rogue_dhcp_dns
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687e4e26eb008331b7a39b1ef111da7a