### PR TITLE
Enhance web UI with log viewer

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -14,9 +14,13 @@
             <q-toolbar>
                 <q-toolbar-title>P4wnP1-O2 Web UI</q-toolbar-title>
             </q-toolbar>
+            <q-tabs v-model="tab" class="text-white" inline-label>
+                <q-tab name="payloads" label="Payloads" />
+                <q-tab name="log" label="Run Log" />
+            </q-tabs>
         </q-header>
         <q-page-container>
-            <q-page class="q-pa-md">
+            <q-page v-show="tab === 'payloads'" class="q-pa-md">
                 <q-btn label="Refresh" color="primary" @click="fetchPayloads"></q-btn>
                 <q-list bordered class="q-mt-md">
                     <q-item v-for="(info, name) in payloads" :key="name">
@@ -27,6 +31,12 @@
                         </q-item-section>
                     </q-item>
                 </q-list>
+            </q-page>
+            <q-page v-show="tab === 'log'" class="q-pa-md">
+                <q-btn label="Refresh" color="primary" @click="fetchLog"></q-btn>
+                <q-scroll-area class="q-mt-md" style="height:400px">
+                    <pre>{{ logText }}</pre>
+                </q-scroll-area>
             </q-page>
         </q-page-container>
     </q-layout>

--- a/webui/main.js
+++ b/webui/main.js
@@ -1,7 +1,9 @@
 new Vue({
     el: '#q-app',
     data: {
-        payloads: {}
+        payloads: {},
+        tab: 'payloads',
+        logText: ''
     },
     methods: {
         fetchPayloads() {
@@ -18,9 +20,19 @@ new Vue({
             fetch('/api/run/' + p, {method: 'POST'})
                 .then(r => r.text())
                 .then(t => this.$q.notify({message: t, timeout: 2000}));
+        },
+        fetchLog() {
+            fetch('/api/log').then(r => r.text()).then(t => { this.logText = t; });
         }
     },
     mounted() {
         this.fetchPayloads();
+    },
+    watch: {
+        tab(val) {
+            if (val === 'log') {
+                this.fetchLog();
+            }
+        }
     }
 });

--- a/webui/server.py
+++ b/webui/server.py
@@ -8,6 +8,7 @@ BASE_DIR = os.getenv('P4WN_HOME', '/opt/p4wnp1')
 CFG = os.path.join(BASE_DIR, 'config/payload.json')
 ACTIVE = os.path.join(BASE_DIR, 'config/active_payload')
 RUNNER = os.path.join(BASE_DIR, 'run_payload.sh')
+LOG_FILE = os.path.join(BASE_DIR, 'logs/runner.log')
 
 app = Flask(__name__, static_folder=os.path.dirname(__file__))
 
@@ -48,6 +49,20 @@ def run_payload(payload):
         f.write(payload)
     result = subprocess.run(['bash', RUNNER], capture_output=True, text=True)
     return result.stdout + result.stderr
+
+@app.route('/api/log')
+def get_log():
+    """Return the tail of the runner log."""
+    lines = request.args.get('lines', 100)
+    try:
+        lines = int(lines)
+    except ValueError:
+        lines = 100
+    if not os.path.exists(LOG_FILE):
+        return ""
+    with open(LOG_FILE) as f:
+        data = f.readlines()
+    return ''.join(data[-lines:])
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
## Summary
- add log viewing endpoint to `server.py`
- create tabbed UI with a new "Run Log" tab
- add log fetching logic in `main.js`

## Testing
- `python3 -m py_compile webui/server.py`
- `pip install flask`
- `python3 webui/server.py` *(runs)*

------
https://chatgpt.com/codex/tasks/task_e_687e5389e7f48331be447aca2aa447c8