### PR TITLE
Add payload listing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ To execute the currently selected payload (as defined in
 sudo /opt/p4wnp1/run.sh
 ```
 
+### 🔍 List available payloads
+
+Quickly view which payloads are available (and whether they are
+enabled) using the helper script:
+
+```bash
+python3 /opt/p4wnp1/tools/payload_manager.py list
+```
+
 ---
 
 ## 📡 OLED Menu (WIP)

--- a/tools/payload_manager.py
+++ b/tools/payload_manager.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Simple payload management helper."""
+import json
+import os
+import argparse
+
+P4WN_HOME = os.getenv("P4WN_HOME", "/opt/p4wnp1")
+CONFIG_PATH = os.path.join(P4WN_HOME, "config/payload.json")
+
+
+def load_payloads():
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def list_payloads():
+    payloads = load_payloads()
+    for name, meta in payloads.items():
+        status = "enabled" if meta.get("enabled", False) else "disabled"
+        ptype = meta.get("type", "?")
+        path = meta.get("path", "")
+        print(f"{name}\t{ptype}\t{status}\t{path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="P4wnP1 payload manager")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("list", help="List available payloads")
+
+    args = parser.parse_args()
+    if args.cmd == "list":
+        list_payloads()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `payload_manager.py` helper to list configured payloads
- document usage of the helper in the README

## Testing
- `python3 -m py_compile $(find . -name '*.py')`
- `shellcheck $(find . -name '*.sh')`

------
https://chatgpt.com/codex/tasks/task_e_687e502ccfec8331ac41d939c3673e0c