### PR TITLE
Fix CLI quoting in Gotchi module

### DIFF
--- a/gotchi/cli.py
+++ b/gotchi/cli.py
@@ -89,7 +89,7 @@ def harvest(
     # override cfg path & wordlist on-the-fly
     g = Gotchi(cfg_path=config)
     # honour --iface flag
-    g.cfg.setdefault(\"hw\", {})[\"iface\"] = iface
+    g.cfg.setdefault("hw", {})["iface"] = iface
                      
     if wordlist:
         g.converter.wordlists = [str(wordlist.expanduser())]
@@ -114,7 +114,7 @@ def live(
 ):
     _setup_logging(quiet)
     g = Gotchi(cfg_path=config)
-    g.cfg.setdefault(\"hw\", {})[\"iface\"] = iface
+    g.cfg.setdefault("hw", {})["iface"] = iface
 
     async def _run_forever():
         with g:


### PR DESCRIPTION
## Summary
- fix invalid quote escapes in gotchi CLI

## Testing
- `python -m py_compile $(git ls-files 'gotchi/*.py' 'gotchi/*/*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e829162c48331a6b268fedeccbbe4